### PR TITLE
Update server.sls

### DIFF
--- a/redis/server.sls
+++ b/redis/server.sls
@@ -84,6 +84,8 @@ redis_config:
 {% else %}
     - source: {{ redis_settings.source_path }}
 {% endif %}
+    - require_in:
+      - file: redis_service
 
 {% if install_from == 'source' %}
 redis-initd:


### PR DESCRIPTION
Add require_in when  in redis_config id to ensure service is restarted when redis is installed from first time in Debian family systems